### PR TITLE
Migrate from deprecated Aeron C++ API to C++ Wrapper API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ CMDEF_ADD_LIBRARY(
 )
 
 TARGET_LINK_LIBRARIES(${ASYNC_FUNCTION_EXECUTION_TARGET_NAME}-shared PUBLIC
+    aeron::aeron_client_wrapper
     aeron::aeron
     aeron::aeron_client_shared
     aeron::aeron_driver

--- a/include/bringauto/async_function_execution/clients/AeronClient.hpp
+++ b/include/bringauto/async_function_execution/clients/AeronClient.hpp
@@ -4,10 +4,10 @@
 #include <bringauto/async_function_execution/Constants.hpp>
 #include <bringauto/async_function_execution/TimeoutIdleStrategy.hpp>
 
-#include <Aeron.h>
-#include <FragmentAssembler.h>
+#include <wrapper/Aeron.h>
+#include <wrapper/FragmentAssembler.h>
 #include <ranges>
-#include <concurrent/BackOffIdleStrategy.h>
+#include <wrapper/concurrent/BackOffIdleStrategy.h>
 
 
 


### PR DESCRIPTION
Replace deprecated `<Aeron.h>`, `<FragmentAssembler.h>`, `<concurrent/BackOffIdleStrategy.h>` includes with `wrapper/` prefixed equivalents in `AeronClient.hpp`, and add `aeron::aeron_client_wrapper` as the first link library to fix the include guard collision on `CountersReader.h`.

Eliminates the deprecation warning about removal in Aeron 1.50.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management and code organization for improved modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->